### PR TITLE
Fix IOS: Plugin fail when no carrier is found

### DIFF
--- a/src/ios/DeviceMeta.m
+++ b/src/ios/DeviceMeta.m
@@ -80,6 +80,9 @@
 - (NSString *)getNetworkProvider {
     CTTelephonyNetworkInfo *netinfo = [[CTTelephonyNetworkInfo alloc] init];
     CTCarrier *carrier = [netinfo subscriberCellularProvider];
+    if ([carrier carrierName] == NULL) {
+        return @"";
+    }
     return @"%@M", [carrier carrierName];
 }
 


### PR DESCRIPTION
There is no provider on a iPad
